### PR TITLE
chore(tsconfig): explicit rootDir for TypeScript 6.0 compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "declarationMap": true,
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "./src",
     "removeComments": true,
     "newLine": "lf",
 


### PR DESCRIPTION
## Summary

One-line tsconfig change: add \`\"rootDir\": \"./src\"\` to compilerOptions. Required for TypeScript 6.0 (which made the previously-inferred rootDir explicit), forward- and backward-compatible with TypeScript 5.x.

## Why

Dependabot PR #34 (typescript 5.9.3 → 6.0.2) currently fails build on Node 22 with:

\`\`\`
tsconfig.json(13,5): error TS5011: The common source directory of 'tsconfig.json' is './src'. The 'rootDir' setting must be explicitly set to this or another path to adjust your output's file layout.
Visit https://aka.ms/ts6 for migration information.
\`\`\`

This change makes the inferred value explicit. After merge, dependabot rebases #34 and it should pass.

## Backward Compatibility

✅ **Unchanged on TS 5.9.x.** \`rootDir\` has been a supported option for years; making it explicit just locks in what TS 5.x was already inferring.

## Verification

Verified locally on the current pinned TypeScript (5.9.x):

- \`npm run build\` — clean
- \`npm run type-check\` — clean
- \`npm run lint\` — clean
- \`npm test\` — 5490 / 5490 tests pass across 231 suites

## Size: Small ✓

One-line config change.

🤖 Generated with [Claude Code](https://claude.ai/code)