### PR TITLE
chore(jest): declare types: ['node', 'jest'] for TypeScript 6.0 compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -57,6 +57,9 @@ export default {
         strict: true,
         esModuleInterop: true,
         skipLibCheck: true,
+        // TypeScript 6.0 stopped auto-including all @types/* packages globally;
+        // declare the ones the test suite needs (jest globals + node).
+        types: ['node', 'jest'],
       },
     }],
     '^.+\\.jsx?$': ['ts-jest', {
@@ -65,6 +68,7 @@ export default {
         esModuleInterop: true,
         skipLibCheck: true,
         allowJs: true,
+        types: ['node', 'jest'],
       },
     }],
   },


### PR DESCRIPTION
## Summary

Pairs with #48 (already merged — `rootDir` fix). TypeScript 6.0 stopped auto-including all `@types/*` packages globally. The build is fine (src/ uses no jest globals), but the test compile breaks:

\`\`\`
tests/setup.ts:10:1 - error TS2304: Cannot find name 'afterEach'.
tests/setup.ts:28:1 - error TS2304: Cannot find name 'afterAll'.
\`\`\`

Adding \`types: ['node', 'jest']\` to the inline ts-jest \`tsconfig\` in \`jest.config.js\` (both the .ts and .js transformers) restores them.

## Why this lives in jest.config.js, not tsconfig.json

\`tsconfig.json\` covers the src/-only build via \`include: [\"src/**/*\"]\`; src/ has no jest globals so it doesn't need the types declaration. The test transformer is the breakage point.

## Backward Compatibility

✅ **Unchanged on TS 5.9.x.** Verified:
- \`npm run lint\` — clean on both TS 5.9.3 and TS 6.0.2
- \`npm run type-check\` — clean on both
- \`npm test\` — 5490 / 5490 tests pass on both

(TS 6.0 was tested locally via \`npm install --no-save typescript@6.0.2\`.)

## Effect on #34

After this lands and dependabot rebases #34, that PR's CI should now pass: rootDir is resolved by #48 and jest globals are resolved here.

## Size: Small ✓

4-line jest.config.js change.

🤖 Generated with [Claude Code](https://claude.ai/code)