### PR TITLE
chore(lint): apply no-unnecessary-type-assertion fixes from typescript-eslint 8.59

### DIFF
--- a/src/api/style-rules-client.ts
+++ b/src/api/style-rules-client.ts
@@ -163,7 +163,7 @@ export class StyleRulesClient extends HttpClient {
     const wire = await this.makeJsonRequest<StyleRuleWireShape>(
       'PUT',
       `/v3/style_rules/${encodeURIComponent(styleId)}/configured_rules`,
-      rules as unknown as Record<string, unknown>,
+      rules,
     );
     return mapStyleRuleDetailed(wire);
   }

--- a/src/cli/commands/config.ts
+++ b/src/cli/commands/config.ts
@@ -38,7 +38,7 @@ export class ConfigCommand {
       }
       return value;
     }
-    return this.maskSensitiveValues(this.config.get() as unknown as Record<string, unknown>);
+    return this.maskSensitiveValues(this.config.get());
   }
 
   /**
@@ -57,7 +57,7 @@ export class ConfigCommand {
     const config = this.config.get();
 
     // Mask sensitive values
-    return this.maskSensitiveValues(config as unknown as Record<string, unknown>);
+    return this.maskSensitiveValues(config);
   }
 
   /**

--- a/src/cli/commands/sync/register-sync-audit.ts
+++ b/src/cli/commands/sync/register-sync-audit.ts
@@ -122,6 +122,6 @@ async function handleSyncAudit(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-export.ts
+++ b/src/cli/commands/sync/register-sync-export.ts
@@ -72,6 +72,6 @@ async function handleSyncExport(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-init.ts
+++ b/src/cli/commands/sync/register-sync-init.ts
@@ -214,6 +214,6 @@ async function handleSyncInit(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    handleError(error as Error);
+    handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-push.ts
+++ b/src/cli/commands/sync/register-sync-push.ts
@@ -75,6 +75,6 @@ async function handleSyncPush(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-resolve.ts
+++ b/src/cli/commands/sync/register-sync-resolve.ts
@@ -103,6 +103,6 @@ async function handleSyncResolve(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-root.ts
+++ b/src/cli/commands/sync/register-sync-root.ts
@@ -142,7 +142,7 @@ async function handleSyncRoot(
       }
     }
     const syncCommand = await createSyncCommand(deps);
-    const result = await syncCommand.run(options as Parameters<typeof syncCommand.run>[0]);
+    const result = await syncCommand.run(options);
     if (result.driftDetected) {
       // Soft exit — set exitCode and return so in-flight writes / auto-commit
       // steps / the --watch event loop drain cleanly instead of being killed
@@ -154,6 +154,6 @@ async function handleSyncRoot(
     if (options['format'] === 'json') {
       emitJsonErrorAndExit(error);
     }
-    handleError(error as Error);
+    handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-status.ts
+++ b/src/cli/commands/sync/register-sync-status.ts
@@ -72,6 +72,6 @@ async function handleSyncStatus(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/cli/commands/sync/register-sync-validate.ts
+++ b/src/cli/commands/sync/register-sync-validate.ts
@@ -79,6 +79,6 @@ async function handleSyncValidate(
     if (options.format === 'json') {
       emitJsonErrorAndExit(error);
     }
-    deps.handleError(error as Error);
+    deps.handleError(error);
   }
 }

--- a/src/formats/json.ts
+++ b/src/formats/json.ts
@@ -244,7 +244,7 @@ export class JsonFormatParser implements FormatParser {
         }
       } else if (typeof val === 'object' && val !== null && !Array.isArray(val)) {
         this.removeDeletedKeys(val, key, translations, flatKeyInfo);
-        if (Object.keys(val as Record<string, unknown>).length === 0) {
+        if (Object.keys(val).length === 0) {
           delete record[prop];
         }
       }

--- a/src/services/detect.ts
+++ b/src/services/detect.ts
@@ -21,7 +21,7 @@ export class DetectService {
     }
 
     const result = await this.client.translate(text, {
-      targetLang: 'en' as Language,
+      targetLang: 'en',
     });
 
     if (!result.detectedSourceLang) {

--- a/src/services/watch.ts
+++ b/src/services/watch.ts
@@ -271,7 +271,7 @@ export class WatchService {
       await this.fileTranslationService.translateFile(
         filePath,
         outputPath,
-        { ...baseOptions, targetLang } as TranslationOptions,
+        { ...baseOptions, targetLang },
         { preserveCode }
       );
 

--- a/src/sync/sync-config.ts
+++ b/src/sync/sync-config.ts
@@ -483,7 +483,7 @@ export function validateSyncConfig(raw: unknown): SyncConfig {
   }
 
   return {
-    version: obj['version'] as number,
+    version: obj['version'],
     source_locale: obj['source_locale'],
     target_locales: obj['target_locales'] as string[],
     buckets: obj['buckets'] as Record<string, SyncBucketConfig>,

--- a/src/sync/tms-client.ts
+++ b/src/sync/tms-client.ts
@@ -18,7 +18,7 @@ function sanitizePullKeysResponse(raw: unknown): Record<string, string> {
       'Check that your TMS server returns the documented shape: {"<key>": "<translation>", ...}.',
     );
   }
-  const keys = Object.keys(raw as Record<string, unknown>);
+  const keys = Object.keys(raw);
   if (keys.length > MAX_PULL_KEY_COUNT) {
     throw new ValidationError(
       `TMS pull response exceeds MAX_PULL_KEY_COUNT (${MAX_PULL_KEY_COUNT})`,

--- a/src/types/glossary.ts
+++ b/src/types/glossary.ts
@@ -57,7 +57,7 @@ export function normalizeGlossaryInfo(response: GlossaryApiResponse): GlossaryIn
     source_lang = Array.from(sourceLangs)[0]!;
   } else {
     Logger.warn('Glossary has empty dictionaries; defaulting source language to "en"');
-    source_lang = 'en' as Language;
+    source_lang = 'en';
   }
 
   return {

--- a/tests/integration/sync-init-format-choices.integration.test.ts
+++ b/tests/integration/sync-init-format-choices.integration.test.ts
@@ -16,10 +16,10 @@ import type { ServiceDeps } from '../../src/cli/commands/service-factory';
 function makeDeps(): ServiceDeps {
   const handleError = jest.fn();
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: handleError as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/integration/sync.integration.test.ts
+++ b/tests/integration/sync.integration.test.ts
@@ -2078,8 +2078,8 @@ describe('Sync Integration — translation memory', () => {
         const tmThresholdRaw = parsed['translation_memory_threshold'];
         capture.push({
           targetLang,
-          tmId: Array.isArray(tmIdRaw) ? tmIdRaw[0] : (tmIdRaw as string | undefined),
-          tmThreshold: Array.isArray(tmThresholdRaw) ? tmThresholdRaw[0] : (tmThresholdRaw as string | undefined),
+          tmId: Array.isArray(tmIdRaw) ? tmIdRaw[0] : (tmIdRaw),
+          tmThreshold: Array.isArray(tmThresholdRaw) ? tmThresholdRaw[0] : (tmThresholdRaw),
           body: parsed,
         });
         const texts = getTexts(rawBody);

--- a/tests/unit/cli-translate-workflow.test.ts
+++ b/tests/unit/cli-translate-workflow.test.ts
@@ -11,7 +11,6 @@ import { FileTranslationService } from '../../src/services/file-translation.js';
 import { DeepLClient, LanguageInfo } from '../../src/api/deepl-client.js';
 import { ConfigService } from '../../src/storage/config.js';
 import { CacheService } from '../../src/storage/cache.js';
-import { Language } from '../../src/types/index.js';
 import { TEST_API_KEY, createMockConfigService, createMockCacheService } from '../helpers';
 
 describe('Translation Workflow Integration', () => {
@@ -450,8 +449,8 @@ describe('Translation Workflow Integration', () => {
 
     it('should get supported source languages', async () => {
       const mockLanguages: LanguageInfo[] = [
-        { language: 'en' as Language, name: 'English' },
-        { language: 'de' as Language, name: 'German' },
+        { language: 'en', name: 'English' },
+        { language: 'de', name: 'German' },
       ];
 
       jest.spyOn(client, 'getSupportedLanguages').mockResolvedValue(mockLanguages);
@@ -463,8 +462,8 @@ describe('Translation Workflow Integration', () => {
 
     it('should get supported target languages', async () => {
       const mockLanguages: LanguageInfo[] = [
-        { language: 'es' as Language, name: 'Spanish' },
-        { language: 'fr' as Language, name: 'French' },
+        { language: 'es', name: 'Spanish' },
+        { language: 'fr', name: 'French' },
       ];
 
       jest.spyOn(client, 'getSupportedLanguages').mockResolvedValue(mockLanguages);
@@ -475,7 +474,7 @@ describe('Translation Workflow Integration', () => {
     });
 
     it('should cache language results for 24 hours', async () => {
-      const mockLanguages: LanguageInfo[] = [{ language: 'en' as Language, name: 'English' }];
+      const mockLanguages: LanguageInfo[] = [{ language: 'en', name: 'English' }];
 
       const getSpy = jest.spyOn(client, 'getSupportedLanguages').mockResolvedValue(mockLanguages);
 

--- a/tests/unit/cli/register-sync-force-help.test.ts
+++ b/tests/unit/cli/register-sync-force-help.test.ts
@@ -15,10 +15,10 @@ import type { ServiceDeps } from '../../../src/cli/commands/service-factory';
 
 function makeDeps(): ServiceDeps {
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: jest.fn() as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/unit/cli/register-sync-init.test.ts
+++ b/tests/unit/cli/register-sync-init.test.ts
@@ -16,10 +16,10 @@ import type { ServiceDeps } from '../../../src/cli/commands/service-factory';
 
 function makeDeps(handleError: jest.Mock): ServiceDeps {
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: handleError as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/unit/cli/register-sync-root.test.ts
+++ b/tests/unit/cli/register-sync-root.test.ts
@@ -26,10 +26,10 @@ const { createSyncCommand: mockCreateSyncCommand } =
 
 function makeDeps(handleError: jest.Mock): ServiceDeps {
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: handleError as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/unit/cli/register-sync-scan-context-help.test.ts
+++ b/tests/unit/cli/register-sync-scan-context-help.test.ts
@@ -13,10 +13,10 @@ import type { ServiceDeps } from '../../../src/cli/commands/service-factory';
 
 function makeDeps(): ServiceDeps {
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: jest.fn() as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/unit/cli/register-sync-tms-help.test.ts
+++ b/tests/unit/cli/register-sync-tms-help.test.ts
@@ -13,10 +13,10 @@ import type { ServiceDeps } from '../../../src/cli/commands/service-factory';
 
 function makeDeps(): ServiceDeps {
   return {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: jest.fn() as unknown as ServiceDeps['handleError'],
   };
 }

--- a/tests/unit/cli/register-sync.commander-snapshot.test.ts
+++ b/tests/unit/cli/register-sync.commander-snapshot.test.ts
@@ -64,10 +64,10 @@ function snapshotCommand(cmd: Command): CommandSnapshot {
 function buildSyncTree(): CommandSnapshot {
   const program = new Command();
   const deps: ServiceDeps = {
-    createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-    getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-    getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-    getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+    createDeepLClient: jest.fn(),
+    getApiKeyAndOptions: jest.fn(),
+    getConfigService: jest.fn(),
+    getCacheService: jest.fn(),
     handleError: jest.fn() as unknown as ServiceDeps['handleError'],
   };
   registerSync(program, deps);
@@ -101,10 +101,10 @@ describe('register-sync commander tree', () => {
   it('keeps the hidden glossary-report rejector registered', () => {
     const program = new Command();
     const deps: ServiceDeps = {
-      createDeepLClient: jest.fn() as unknown as ServiceDeps['createDeepLClient'],
-      getApiKeyAndOptions: jest.fn() as unknown as ServiceDeps['getApiKeyAndOptions'],
-      getConfigService: jest.fn() as unknown as ServiceDeps['getConfigService'],
-      getCacheService: jest.fn() as unknown as ServiceDeps['getCacheService'],
+      createDeepLClient: jest.fn(),
+      getApiKeyAndOptions: jest.fn(),
+      getConfigService: jest.fn(),
+      getCacheService: jest.fn(),
       handleError: jest.fn() as unknown as ServiceDeps['handleError'],
     };
     registerSync(program, deps);

--- a/tests/unit/config-service.test.ts
+++ b/tests/unit/config-service.test.ts
@@ -252,7 +252,7 @@ describe('ConfigService', () => {
     it('should validate boolean values', () => {
       expect(() => {
 
-        configService.set('cache.enabled', 'yes' as any);
+        configService.set('cache.enabled', 'yes');
       }).toThrow(/Expected boolean for "cache\.enabled"\. Use true or false\./);
     });
   });

--- a/tests/unit/detect-command.test.ts
+++ b/tests/unit/detect-command.test.ts
@@ -173,7 +173,7 @@ describe('DetectCommand', () => {
 
     it('should produce pretty-printed JSON', () => {
       const output = detectCommand.formatJson({
-        detectedLanguage: 'ja' as any,
+        detectedLanguage: 'ja',
         languageName: 'Japanese',
       });
 

--- a/tests/unit/document-translation-handler.test.ts
+++ b/tests/unit/document-translation-handler.test.ts
@@ -153,7 +153,7 @@ describe('DocumentTranslationHandler', () => {
       mocks.documentTranslationService.translateDocument.mockResolvedValue({
         success: true,
         outputPath: '/tmp/output.pdf',
-      } as any);
+      });
 
       const result = await handler.translateDocument('/tmp/doc.pdf', defaultOptions());
 

--- a/tests/unit/dry-run.test.ts
+++ b/tests/unit/dry-run.test.ts
@@ -217,7 +217,7 @@ describe('--dry-run flag', () => {
         handleError: jest.fn() as jest.Mock & ((error: unknown) => never),
       };
 
-      registerGlossary(program, mockDeps as any);
+      registerGlossary(program, mockDeps);
 
       await program.parseAsync([
         'node', 'deepl', 'glossary', 'delete', 'my-glossary',

--- a/tests/unit/file-translation-handler.test.ts
+++ b/tests/unit/file-translation-handler.test.ts
@@ -107,7 +107,7 @@ describe('FileTranslationHandler', () => {
     mockDocHandler = {
       translateDocument: jest.fn().mockResolvedValue('Translated doc.pdf -> /tmp/output.pdf'),
       ctx: result.ctx,
-    } as unknown as jest.Mocked<DocumentTranslationHandler>;
+    };
 
     handler = new FileTranslationHandler(result.ctx, mockDocHandler);
 
@@ -122,10 +122,10 @@ describe('FileTranslationHandler', () => {
   describe('translateFile()', () => {
     it('should throw ValidationError when no output is specified', async () => {
       await expect(
-        handler.translateFile('/tmp/file.txt', { to: 'de', cache: true } as TranslateOptions)
+        handler.translateFile('/tmp/file.txt', { to: 'de', cache: true })
       ).rejects.toThrow(ValidationError);
       await expect(
-        handler.translateFile('/tmp/file.txt', { to: 'de', cache: true } as TranslateOptions)
+        handler.translateFile('/tmp/file.txt', { to: 'de', cache: true })
       ).rejects.toThrow('Output file path is required');
     });
 
@@ -140,8 +140,8 @@ describe('FileTranslationHandler', () => {
 
     it('should call fileTranslationService.translateFileToMultiple for multi-target', async () => {
       mocks.fileTranslationService.translateFileToMultiple.mockResolvedValue([
-        { targetLang: 'de' as any, text: 'Hallo', outputPath: '/tmp/out/file.de.txt' },
-        { targetLang: 'fr' as any, text: 'Bonjour', outputPath: '/tmp/out/file.fr.txt' },
+        { targetLang: 'de', text: 'Hallo', outputPath: '/tmp/out/file.de.txt' },
+        { targetLang: 'fr', text: 'Bonjour', outputPath: '/tmp/out/file.fr.txt' },
       ]);
 
       const result = await handler.translateFile('/tmp/file.txt', defaultOptions({ to: 'de,fr', output: '/tmp/out' }));
@@ -155,8 +155,8 @@ describe('FileTranslationHandler', () => {
 
       beforeEach(() => {
         mocks.fileTranslationService.translateFileToMultiple.mockResolvedValue([
-          { targetLang: 'de' as any, text: 'Hallo', outputPath: '/tmp/out/file.de.txt' },
-          { targetLang: 'fr' as any, text: 'Bonjour', outputPath: '/tmp/out/file.fr.txt' },
+          { targetLang: 'de', text: 'Hallo', outputPath: '/tmp/out/file.de.txt' },
+          { targetLang: 'fr', text: 'Bonjour', outputPath: '/tmp/out/file.fr.txt' },
         ]);
       });
 

--- a/tests/unit/formatters.test.ts
+++ b/tests/unit/formatters.test.ts
@@ -17,10 +17,10 @@ describe('formatters', () => {
     it('should format single translation as JSON', () => {
       const result: TranslationResult = {
         text: 'Hola',
-        detectedSourceLang: 'en' as Language,
+        detectedSourceLang: 'en',
       };
 
-      const output = formatTranslationJson(result, 'es' as Language);
+      const output = formatTranslationJson(result, 'es');
       const parsed = JSON.parse(output);
 
       expect(parsed.text).toBe('Hola');
@@ -33,7 +33,7 @@ describe('formatters', () => {
         text: 'Hola',
       };
 
-      const output = formatTranslationJson(result, 'es' as Language, true);
+      const output = formatTranslationJson(result, 'es', true);
       const parsed = JSON.parse(output);
 
       expect(parsed.cached).toBe(true);
@@ -44,7 +44,7 @@ describe('formatters', () => {
         text: 'Hola',
       };
 
-      const output = formatTranslationJson(result, 'es' as Language);
+      const output = formatTranslationJson(result, 'es');
       const parsed = JSON.parse(output);
 
       expect(parsed.cached).toBeUndefined();
@@ -55,7 +55,7 @@ describe('formatters', () => {
         text: 'Hola',
       };
 
-      const output = formatTranslationJson(result, 'es' as Language);
+      const output = formatTranslationJson(result, 'es');
       const parsed = JSON.parse(output);
 
       expect(parsed.text).toBe('Hola');
@@ -68,7 +68,7 @@ describe('formatters', () => {
         text: 'Hola',
       };
 
-      const output = formatTranslationJson(result, 'es' as Language);
+      const output = formatTranslationJson(result, 'es');
 
       expect(output).toContain('  "text": "Hola"');
       expect(output).toContain('  "targetLang": "es"');

--- a/tests/unit/glossary-command.test.ts
+++ b/tests/unit/glossary-command.test.ts
@@ -8,7 +8,7 @@
 import { GlossaryCommand } from '../../src/cli/commands/glossary';
 import { GlossaryService } from '../../src/services/glossary';
 import { GlossaryInfo } from '../../src/types/glossary.js';
-import { GlossaryLanguagePair, Language } from '../../src/types/index.js';
+import { GlossaryLanguagePair } from '../../src/types/index.js';
 import * as fs from 'fs';
 import { createMockGlossaryService } from '../helpers/mock-factories';
 
@@ -644,9 +644,9 @@ describe('GlossaryCommand', () => {
   describe('formatLanguagePairs()', () => {
     it('should format language pairs for display', () => {
       const pairs: GlossaryLanguagePair[] = [
-        { sourceLang: 'en' as Language, targetLang: 'es' as Language },
-        { sourceLang: 'de' as Language, targetLang: 'en' as Language },
-        { sourceLang: 'fr' as Language, targetLang: 'de' as Language },
+        { sourceLang: 'en', targetLang: 'es' },
+        { sourceLang: 'de', targetLang: 'en' },
+        { sourceLang: 'fr', targetLang: 'de' },
       ];
 
       const result = glossaryCommand.formatLanguagePairs(pairs);
@@ -664,7 +664,7 @@ describe('GlossaryCommand', () => {
 
     it('should format single language pair', () => {
       const pairs: GlossaryLanguagePair[] = [
-        { sourceLang: 'en' as Language, targetLang: 'de' as Language },
+        { sourceLang: 'en', targetLang: 'de' },
       ];
 
       const result = glossaryCommand.formatLanguagePairs(pairs);

--- a/tests/unit/sync/sync-bucket-walker.test.ts
+++ b/tests/unit/sync/sync-bucket-walker.test.ts
@@ -55,7 +55,7 @@ describe('walkBuckets', () => {
     mockFg.mockReset();
     mockReadFile.mockReset();
     mockStat.mockReset();
-    mockStat.mockResolvedValue({ size: 1024 } as never);
+    mockStat.mockResolvedValue({ size: 1024 });
   });
 
   it('yields one entry per source file with parsed entries', async () => {
@@ -127,7 +127,7 @@ describe('walkBuckets', () => {
   describe('sync.limits enforcement', () => {
     it('skips files whose size exceeds sync.limits.max_file_bytes', async () => {
       mockFg.mockResolvedValue(['/test/locales/en.json'] as never);
-      mockStat.mockResolvedValue({ size: 5_000_000 } as never);
+      mockStat.mockResolvedValue({ size: 5_000_000 });
 
       const config = makeConfig({
         sync: {
@@ -162,7 +162,7 @@ describe('walkBuckets', () => {
 
     it('passes through files within the configured caps', async () => {
       mockFg.mockResolvedValue(['/test/locales/en.json'] as never);
-      mockStat.mockResolvedValue({ size: 100 } as never);
+      mockStat.mockResolvedValue({ size: 100 });
       mockReadFile.mockResolvedValue('{"a":"Hello"}');
 
       const config = makeConfig({
@@ -179,7 +179,7 @@ describe('walkBuckets', () => {
     });
 
     it('skips entire bucket when glob returns more files than sync.limits.max_source_files', async () => {
-      mockFg.mockResolvedValue(Array.from({ length: 10 }, (_, i) => `/test/locales/en/${i}.json`) as never);
+      mockFg.mockResolvedValue(Array.from({ length: 10 }, (_, i) => `/test/locales/en/${i}.json`));
 
       const config = makeConfig({
         sync: {
@@ -197,7 +197,7 @@ describe('walkBuckets', () => {
 
     it('processes the bucket when file count equals max_source_files', async () => {
       mockFg.mockResolvedValue(['/test/locales/en.json'] as never);
-      mockStat.mockResolvedValue({ size: 100 } as never);
+      mockStat.mockResolvedValue({ size: 100 });
       mockReadFile.mockResolvedValue('{"a":"Hello"}');
 
       const config = makeConfig({
@@ -214,7 +214,7 @@ describe('walkBuckets', () => {
 
     it('skips files where a laravel_php parser depth cap is exceeded', async () => {
       mockFg.mockResolvedValue(['/test/lang/en.php'] as never);
-      mockStat.mockResolvedValue({ size: 200 } as never);
+      mockStat.mockResolvedValue({ size: 200 });
       mockReadFile.mockResolvedValue(
         `<?php return ['a' => ['b' => ['c' => ['d' => 'too deep']]]];`,
       );

--- a/tests/unit/sync/sync-command.test.ts
+++ b/tests/unit/sync/sync-command.test.ts
@@ -1,4 +1,4 @@
-import { SyncCommand, type CliSyncOptions } from '../../../src/cli/commands/sync-command';
+import { SyncCommand } from '../../../src/cli/commands/sync-command';
 import type { SyncService, SyncResult, SyncFileResult } from '../../../src/sync/sync-service';
 import { Logger } from '../../../src/utils/logger';
 
@@ -110,7 +110,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput.toLowerCase()).toContain('dry-run');
@@ -121,7 +121,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput.toLowerCase()).toContain('drift');
@@ -132,7 +132,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ format: 'json' } as CliSyncOptions);
+      await command.run({ format: 'json' });
 
       const jsonCall = stdoutWriteSpy.mock.calls.find((c: unknown[]) => {
         try {
@@ -154,7 +154,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput).toContain('500,000 chars');
@@ -166,7 +166,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput).toContain('Pro tier estimate');
@@ -177,7 +177,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput).toContain('Pro tier estimate');
@@ -188,7 +188,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ format: 'json' } as CliSyncOptions);
+      await command.run({ format: 'json' });
 
       const jsonCall = stdoutWriteSpy.mock.calls.find((c: unknown[]) => {
         try { JSON.parse(String(c[0]).trim()); return true; } catch { return false; }
@@ -202,7 +202,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ format: 'json' } as CliSyncOptions);
+      await command.run({ format: 'json' });
 
       const jsonCall = stdoutWriteSpy.mock.calls.find((c: unknown[]) => {
         try { JSON.parse(String(c[0]).trim()); return true; } catch { return false; }
@@ -216,7 +216,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ format: 'json' } as CliSyncOptions);
+      await command.run({ format: 'json' });
 
       const jsonCall = stdoutWriteSpy.mock.calls.find((c: unknown[]) => {
         try { JSON.parse(String(c[0]).trim()); return true; } catch { return false; }
@@ -230,7 +230,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const warnOutput = logWarnSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(warnOutput).toContain('3');
@@ -242,7 +242,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const warnOutput = logWarnSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(warnOutput).toContain('5');
@@ -256,7 +256,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ ci: true } as CliSyncOptions);
+      await command.run({ ci: true });
 
       const syncCall = mockService.sync.mock.calls[0]!;
       const syncOptions = syncCall[1] as Record<string, unknown>;
@@ -273,8 +273,8 @@ describe('SyncCommand', () => {
       const frozenCommand = new SyncCommand(mockServiceFrozen);
       const ciCommand = new SyncCommand(mockServiceCi);
 
-      const frozenResult = await frozenCommand.run({ frozen: true } as CliSyncOptions);
-      const ciResult = await ciCommand.run({ ci: true } as CliSyncOptions);
+      const frozenResult = await frozenCommand.run({ frozen: true });
+      const ciResult = await ciCommand.run({ ci: true });
 
       expect(frozenResult.driftDetected).toBe(ciResult.driftDetected);
       expect(frozenResult.frozen).toBe(ciResult.frozen);
@@ -288,7 +288,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput).not.toContain('$');
@@ -300,7 +300,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map(c => String(c[0])).join('\n');
       expect(infoOutput).toContain('3 new');
@@ -314,7 +314,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ flagForReview: true } as CliSyncOptions);
+      await command.run({ flagForReview: true });
 
       const syncCall = mockService.sync.mock.calls[0]!;
       const syncOptions = syncCall[1] as Record<string, unknown>;
@@ -328,7 +328,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('~4,500 chars');
@@ -340,7 +340,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).not.toContain('This sync');
@@ -351,7 +351,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('across 3 languages');
@@ -362,7 +362,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('across 1 language');
@@ -374,7 +374,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true, format: 'json' } as CliSyncOptions);
+      await command.run({ dryRun: true, format: 'json' });
 
       const jsonCall = stdoutWriteSpy.mock.calls.find((c: unknown[]) => {
         try { JSON.parse(String(c[0]).trim()); return true; } catch { return false; }
@@ -418,7 +418,7 @@ describe('SyncCommand', () => {
       );
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('\u2713 de: 10/10');
@@ -439,7 +439,7 @@ describe('SyncCommand', () => {
       );
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('\u2713 de: 5/5 keys (locales/de.json)');
@@ -456,7 +456,7 @@ describe('SyncCommand', () => {
       );
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('\u2717 de: 8/10');
@@ -467,7 +467,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ dryRun: true } as CliSyncOptions);
+      await command.run({ dryRun: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).not.toMatch(/[✓✗]/);
@@ -479,7 +479,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).not.toMatch(/\d+\/\d+/);
@@ -513,7 +513,7 @@ describe('SyncCommand', () => {
       } as unknown as jest.Mocked<SyncService>;
       const command = new SyncCommand(mockService);
 
-      await command.run({} as CliSyncOptions);
+      await command.run({});
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       const tickMatches = infoOutput.match(/\u2713 de:/g) ?? [];
@@ -528,7 +528,7 @@ describe('SyncCommand', () => {
       const command = new SyncCommand(mockService);
 
       // run() with watch=false should complete normally (watch=true would block)
-      const syncResult = await command.run({ watch: false, debounce: 300 } as CliSyncOptions);
+      const syncResult = await command.run({ watch: false, debounce: 300 });
       expect(syncResult.success).toBe(true);
       expect(mockService.sync).toHaveBeenCalledTimes(1);
     });
@@ -587,7 +587,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const calls = mockExecFile.mock.calls;
       const gitCalls = calls.map((c: unknown[]) => [c[0], c[1]]);
@@ -611,7 +611,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const calls = mockExecFile.mock.calls;
       const gitCalls = calls.map((c: unknown[]) => [c[0], c[1]]);
@@ -625,7 +625,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const gitInvocations = mockExecFile.mock.calls.filter(
         (c: unknown[]) => c[0] === 'git',
@@ -654,7 +654,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const calls = mockExecFile.mock.calls;
       const gitCalls = calls.map((c: unknown[]) => [c[0], c[1]]);
@@ -695,7 +695,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const warnOutput = logWarnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(warnOutput).toContain('Not a git repository');
@@ -711,7 +711,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const calls = mockExecFile.mock.calls;
       const addCalls = calls.filter(
@@ -729,7 +729,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       expect(mockExecFile).not.toHaveBeenCalled();
     });
@@ -739,7 +739,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true, dryRun: true } as CliSyncOptions);
+      await command.run({ autoCommit: true, dryRun: true });
 
       const addCalls = mockExecFile.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes('add'),
@@ -752,7 +752,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const addCalls = mockExecFile.mock.calls.filter(
         (c: unknown[]) => Array.isArray(c[1]) && (c[1] as string[]).includes('add'),
@@ -765,7 +765,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ autoCommit: true } as CliSyncOptions);
+      await command.run({ autoCommit: true });
 
       const infoOutput = logInfoSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(infoOutput).toContain('Auto-committed');
@@ -818,7 +818,7 @@ describe('SyncCommand', () => {
         return process;
       }) as unknown as ProcessOn);
 
-      const runPromise = command.run({ watch: true, debounce: 100 } as CliSyncOptions);
+      const runPromise = command.run({ watch: true, debounce: 100 });
 
       await flushWatchSetup();
 
@@ -846,7 +846,7 @@ describe('SyncCommand', () => {
       const mockService = createMockSyncService(result);
       const command = new SyncCommand(mockService);
 
-      await command.run({ watch: true } as CliSyncOptions);
+      await command.run({ watch: true });
 
       const warnOutput = logWarnSpy.mock.calls.map((c: unknown[]) => String(c[0])).join('\n');
       expect(warnOutput).toContain('No source files to watch');
@@ -902,7 +902,7 @@ describe('SyncCommand', () => {
         return process;
       }) as unknown as ProcessOn);
 
-      const runPromise = command.run({ watch: true, debounce: 50, autoCommit: true } as CliSyncOptions);
+      const runPromise = command.run({ watch: true, debounce: 50, autoCommit: true });
 
       await flushWatchSetup();
 
@@ -952,7 +952,7 @@ describe('SyncCommand', () => {
       // Don't mock process.on — the whole point is to observe real listener
       // churn across repeated invocations. Trigger shutdown by emitting the
       // signal to the real process emitter (listeners only react synchronously).
-      const firstRun = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+      const firstRun = command.run({ watch: true, debounce: 50 });
       await flushWatchSetup();
       // Under heavy CI worker contention the fixed-round flush occasionally
       // returns before watchAndSync has reached its process.on('SIGINT', ...)
@@ -971,7 +971,7 @@ describe('SyncCommand', () => {
       expect(process.listenerCount('SIGTERM')).toBe(sigtermBaseline);
 
       // Second invocation should also add exactly one listener, then remove it.
-      const secondRun = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+      const secondRun = command.run({ watch: true, debounce: 50 });
       await flushWatchSetup();
       for (let i = 0; i < 10 && process.listenerCount('SIGINT') === sigintBaseline; i++) {
         await flushWatchSetup();
@@ -999,7 +999,7 @@ describe('SyncCommand', () => {
         return process;
       }) as unknown as ProcessOn);
 
-      const runPromise = command.run({ watch: true, debounce: 100 } as CliSyncOptions);
+      const runPromise = command.run({ watch: true, debounce: 100 });
 
       await flushWatchSetup();
 
@@ -1043,7 +1043,7 @@ describe('SyncCommand', () => {
           return process;
         }) as unknown as ProcessOn);
 
-        const runPromise = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+        const runPromise = command.run({ watch: true, debounce: 50 });
         await flushWatchSetup();
 
         const initialLoads = mockLoadSyncConfig.mock.calls.length;
@@ -1085,7 +1085,7 @@ describe('SyncCommand', () => {
           return process;
         }) as unknown as ProcessOn);
 
-        const runPromise = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+        const runPromise = command.run({ watch: true, debounce: 50 });
         await flushWatchSetup();
         // Under CI worker contention the fixed-round flush occasionally
         // returns before watcher.on('change', ...) has registered. Loop
@@ -1132,7 +1132,7 @@ describe('SyncCommand', () => {
           return process;
         }) as unknown as ProcessOn);
 
-        const runPromise = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+        const runPromise = command.run({ watch: true, debounce: 50 });
         await flushWatchSetup();
 
         const initialLoads = mockLoadSyncConfig.mock.calls.length;
@@ -1168,7 +1168,7 @@ describe('SyncCommand', () => {
           return process;
         }) as unknown as ProcessOn);
 
-        const runPromise = command.run({ watch: true, debounce: 50 } as CliSyncOptions);
+        const runPromise = command.run({ watch: true, debounce: 50 });
         await flushWatchSetup();
 
         const watchedPaths = mockWatch.mock.calls[0]![0] as string[];

--- a/tests/unit/sync/sync-locale-translator.test.ts
+++ b/tests/unit/sync/sync-locale-translator.test.ts
@@ -84,7 +84,7 @@ function makeConfig(overrides: Partial<ResolvedSyncConfig> = {}): ResolvedSyncCo
     translation: {},
     validation: { validate_after_sync: false },
     ...overrides,
-  } as unknown as ResolvedSyncConfig;
+  };
 }
 
 function makeParser(): FormatParser {

--- a/tests/unit/sync/sync-service.test.ts
+++ b/tests/unit/sync/sync-service.test.ts
@@ -1281,7 +1281,7 @@ describe('SyncService', () => {
           return ['locales/en.json', 'locales/old-path/en.json'];
         }
         return ['/test/locales/en.json'];
-      }) as never);
+      }));
       mockReadFile.mockImplementation(async (p: unknown) => {
         if (String(p) === '/test/locales/en.json') return SOURCE_JSON;
         throw new Error('ENOENT');
@@ -1320,7 +1320,7 @@ describe('SyncService', () => {
           return [];
         }
         return ['/test/locales/en.json'];
-      }) as never);
+      }));
       mockReadFile.mockImplementation(async (p: unknown) => {
         if (String(p) === '/test/locales/en.json') return SOURCE_JSON;
         throw new Error('ENOENT');

--- a/tests/unit/sync/sync-status.test.ts
+++ b/tests/unit/sync/sync-status.test.ts
@@ -31,7 +31,7 @@ function makeConfig(overrides: Partial<ResolvedSyncConfig> = {}): ResolvedSyncCo
     projectRoot: '/test',
     overrides: {},
     ...overrides,
-  } as ResolvedSyncConfig;
+  };
 }
 
 function makeParser(): FormatParser {

--- a/tests/unit/sync/sync-tms.test.ts
+++ b/tests/unit/sync/sync-tms.test.ts
@@ -100,7 +100,7 @@ function makeStubParser(
       return single!;
     }),
     reconstruct: jest.fn((content) => content),
-  } as FormatParser;
+  };
 }
 
 function makeRegistryWithParser(parser: FormatParser): FormatRegistry {

--- a/tests/unit/sync/sync-validate.test.ts
+++ b/tests/unit/sync/sync-validate.test.ts
@@ -27,7 +27,7 @@ function makeConfig(overrides: Partial<ResolvedSyncConfig> = {}): ResolvedSyncCo
     projectRoot: '/test',
     overrides: {},
     ...overrides,
-  } as ResolvedSyncConfig;
+  };
 }
 
 function makeParser(sourceEntries: ExtractedEntry[], targetEntries: ExtractedEntry[]): FormatParser {

--- a/tests/unit/sync/tms-client.test.ts
+++ b/tests/unit/sync/tms-client.test.ts
@@ -162,7 +162,7 @@ describe('TmsClient timeout', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       timeoutMs: 5000,
       retry: { maxAttempts: 1 },
     });
@@ -186,7 +186,7 @@ describe('TmsClient retry', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 2, jitter: false },
     });
     await expect(client.pushKey('k', 'de', 'v')).resolves.toBeUndefined();
@@ -204,7 +204,7 @@ describe('TmsClient retry', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 2, jitter: false },
     });
     await expect(client.pushKey('k', 'de', 'v')).rejects.toThrow(/503/);
@@ -222,7 +222,7 @@ describe('TmsClient retry', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 3, baseDelayMs: 1, maxDelayMs: 2, jitter: false },
     });
     await expect(client.pushKey('k', 'de', 'v')).rejects.toThrow(ConfigError);
@@ -244,7 +244,7 @@ describe('TmsClient error body', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 1 },
     });
     await expect(client.pushKey('k', 'de', 'v')).rejects.toThrow(/oops/);
@@ -262,7 +262,7 @@ describe('TmsClient error body', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 1 },
     });
     await expect(client.pushKey('k', 'de', 'v')).rejects.toThrow(
@@ -282,7 +282,7 @@ describe('TmsClient error body', () => {
       serverUrl: 'https://tms.example.com',
       projectId: 'p',
       apiKey: 'k',
-      fetch: stubFetch as unknown as typeof globalThis.fetch,
+      fetch: stubFetch,
       retry: { maxAttempts: 1 },
     });
     await expect(client.pushKey('k', 'de', 'v')).rejects.toThrow(

--- a/tests/unit/text-translation-handler.test.ts
+++ b/tests/unit/text-translation-handler.test.ts
@@ -139,8 +139,8 @@ describe('TextTranslationHandler', () => {
 
     it('should call translateToMultiple() for comma-separated targets', async () => {
       mocks.translationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'de' as any, text: 'Hallo' },
-        { targetLang: 'fr' as any, text: 'Bonjour' },
+        { targetLang: 'de', text: 'Hallo' },
+        { targetLang: 'fr', text: 'Bonjour' },
       ]);
 
       const result = await handler.translateText('Hello', defaultOptions({ to: 'de,fr' }));
@@ -352,9 +352,9 @@ describe('TextTranslationHandler', () => {
             { translation_memory_id: TM_UUID, name: 'my-tm', source_language: 'en', target_languages: ['de'] },
           ]);
           mocks.translationService.translateToMultiple.mockResolvedValue([
-            { targetLang: 'de' as any, text: 'Hallo' },
-            { targetLang: 'de' as any, text: 'Hallo' },
-            { targetLang: 'de' as any, text: 'Hallo' },
+            { targetLang: 'de', text: 'Hallo' },
+            { targetLang: 'de', text: 'Hallo' },
+            { targetLang: 'de', text: 'Hallo' },
           ]);
 
           await handler.translateText('Hello', defaultOptions({
@@ -378,7 +378,7 @@ describe('TextTranslationHandler', () => {
             { translation_memory_id: TM_UUID, name: 'my-tm', source_language: 'en', target_languages: ['de'] },
           ]);
           mocks.translationService.translateToMultiple.mockResolvedValue([
-            { targetLang: 'de' as any, text: 'Hallo' },
+            { targetLang: 'de', text: 'Hallo' },
           ]);
 
           await handler.translateText('Hello', defaultOptions({
@@ -417,8 +417,8 @@ describe('TextTranslationHandler', () => {
         });
         try {
           mocks.translationService.translateToMultiple.mockResolvedValue([
-            { targetLang: 'de' as any, text: 'Hallo' },
-            { targetLang: 'fr' as any, text: 'Bonjour' },
+            { targetLang: 'de', text: 'Hallo' },
+            { targetLang: 'fr', text: 'Bonjour' },
           ]);
 
           const result = await handler.translateText('Hello', defaultOptions({ to: 'de,fr', format: 'table' }));
@@ -442,8 +442,8 @@ describe('TextTranslationHandler', () => {
         });
         try {
           mocks.translationService.translateToMultiple.mockResolvedValue([
-            { targetLang: 'de' as any, text: 'Hallo' },
-            { targetLang: 'fr' as any, text: 'Bonjour' },
+            { targetLang: 'de', text: 'Hallo' },
+            { targetLang: 'fr', text: 'Bonjour' },
           ]);
 
           const result = await handler.translateText('Hello', defaultOptions({ to: 'de,fr', format: 'table' }));
@@ -460,7 +460,7 @@ describe('TextTranslationHandler', () => {
       it('should append billed characters metadata when present', async () => {
         mocks.translationService.translate.mockResolvedValue({
           text: 'translated',
-          detectedSourceLang: 'en' as any,
+          detectedSourceLang: 'en',
           billedCharacters: 42,
         });
 
@@ -471,7 +471,7 @@ describe('TextTranslationHandler', () => {
       it('should append model type metadata when present', async () => {
         mocks.translationService.translate.mockResolvedValue({
           text: 'translated',
-          detectedSourceLang: 'en' as any,
+          detectedSourceLang: 'en',
           modelTypeUsed: 'quality_optimized',
         });
 
@@ -483,7 +483,7 @@ describe('TextTranslationHandler', () => {
     it('should call warnIgnoredOptions for multi-target translation', async () => {
       const { Logger } = jest.requireMock('../../src/utils/logger');
       mocks.translationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'de' as any, text: 'Hallo' },
+        { targetLang: 'de', text: 'Hallo' },
       ]);
 
       await handler.translateText('Hello', defaultOptions({

--- a/tests/unit/translate-command.test.ts
+++ b/tests/unit/translate-command.test.ts
@@ -1992,8 +1992,8 @@ describe('TranslateCommand', () => {
 
     it('should pass styleId in translateToMultiple', async () => {
       mockTranslationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'es' as any, text: 'Hola' },
-        { targetLang: 'fr' as any, text: 'Bonjour' },
+        { targetLang: 'es', text: 'Hola' },
+        { targetLang: 'fr', text: 'Bonjour' },
       ]);
 
       await translateCommand.translateText('Hello', {
@@ -2129,8 +2129,8 @@ describe('TranslateCommand', () => {
 
     it('should allow core + extended mix without restricted options', async () => {
       mockTranslationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'es' as any, text: 'Hola' },
-        { targetLang: 'sw' as any, text: 'Hujambo' },
+        { targetLang: 'es', text: 'Hola' },
+        { targetLang: 'sw', text: 'Hujambo' },
       ]);
 
       await translateCommand.translateText('Hello', { to: 'es,sw' });
@@ -2471,7 +2471,7 @@ describe('TranslateCommand', () => {
     it('should return JSON format for single text translation', async () => {
       mockTranslationService.translate.mockResolvedValue({
         text: 'Hola',
-        detectedSourceLang: 'en' as any,
+        detectedSourceLang: 'en',
       });
 
       const result = await translateCommand.translateText('Hello', {
@@ -2486,8 +2486,8 @@ describe('TranslateCommand', () => {
 
     it('should return JSON format for multi-target translation', async () => {
       mockTranslationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'es' as any, text: 'Hola' },
-        { targetLang: 'fr' as any, text: 'Bonjour' },
+        { targetLang: 'es', text: 'Hola' },
+        { targetLang: 'fr', text: 'Bonjour' },
       ]);
 
       const result = await translateCommand.translateText('Hello', {
@@ -2510,8 +2510,8 @@ describe('TranslateCommand', () => {
       });
       try {
         mockTranslationService.translateToMultiple.mockResolvedValue([
-          { targetLang: 'es' as any, text: 'Hola' },
-          { targetLang: 'fr' as any, text: 'Bonjour' },
+          { targetLang: 'es', text: 'Hola' },
+          { targetLang: 'fr', text: 'Bonjour' },
         ]);
 
         const result = await translateCommand.translateText('Hello', {
@@ -2602,7 +2602,7 @@ describe('TranslateCommand', () => {
 
     it('should pass showBilledCharacters to translateToMultiple', async () => {
       mockTranslationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'es' as any, text: 'Hola' },
+        { targetLang: 'es', text: 'Hola' },
       ]);
 
       await translateCommand.translateText('Hello', {
@@ -2695,7 +2695,7 @@ describe('TranslateCommand', () => {
 
     it('should pass skipCache to translateToMultiple', async () => {
       mockTranslationService.translateToMultiple.mockResolvedValue([
-        { targetLang: 'es' as any, text: 'Hola' },
+        { targetLang: 'es', text: 'Hola' },
       ]);
 
       await translateCommand.translateText('Hello', {

--- a/tests/unit/translation-options-factory.test.ts
+++ b/tests/unit/translation-options-factory.test.ts
@@ -82,7 +82,7 @@ describe('translation-options-factory', () => {
     it('resolves glossaryId when options.glossary is set', async () => {
       glossarySvc.resolveGlossaryId.mockResolvedValue('glos-123');
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de', glossary: 'my-glossary' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', glossary: 'my-glossary' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -93,7 +93,7 @@ describe('translation-options-factory', () => {
 
     it('skips glossary resolution when options.glossary is absent', async () => {
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -104,7 +104,7 @@ describe('translation-options-factory', () => {
 
     it('resolves TM id and sets threshold when options.translationMemory is set', async () => {
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm', tmThreshold: 80 } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm', tmThreshold: 80 }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -115,7 +115,7 @@ describe('translation-options-factory', () => {
 
     it('defaults modelType to quality_optimized when TM is set and modelType was absent', async () => {
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -125,7 +125,7 @@ describe('translation-options-factory', () => {
 
     it('preserves an already-set modelType when TM is also set', async () => {
       const base: Record<string, unknown> = { targetLang: 'de', modelType: 'quality_optimized' };
-      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm', modelType: 'quality_optimized' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm', modelType: 'quality_optimized' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -135,7 +135,7 @@ describe('translation-options-factory', () => {
 
     it('omits translationMemoryThreshold when tmThreshold is undefined', async () => {
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'my-tm' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],
@@ -148,7 +148,7 @@ describe('translation-options-factory', () => {
         { translation_memory_id: 'tm-multi', name: 'multi-tm', source_language: 'en', target_languages: ['de'], ready: true },
       ]) as never;
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'multi-tm' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de', from: 'en', translationMemory: 'multi-tm' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'], // single-pair TMs for each target — here one target matches
@@ -158,7 +158,7 @@ describe('translation-options-factory', () => {
 
     it('skips TM block when options.translationMemory is absent', async () => {
       const base: Record<string, unknown> = { targetLang: 'de' };
-      await applySharedTmAndGlossary(base, { to: 'de' } as TranslateOptions, {
+      await applySharedTmAndGlossary(base, { to: 'de' }, {
         glossaryService: glossarySvc,
         translationService: translationSvc,
         targets: ['de'],

--- a/tests/unit/translation-service.test.ts
+++ b/tests/unit/translation-service.test.ts
@@ -770,8 +770,8 @@ describe('TranslationService', () => {
   describe('getSupportedLanguages()', () => {
     it('should return supported source languages', async () => {
       mockDeepLClient.getSupportedLanguages.mockResolvedValue([
-        { language: 'en' as Language, name: 'English' },
-        { language: 'es' as Language, name: 'Spanish' },
+        { language: 'en', name: 'English' },
+        { language: 'es', name: 'Spanish' },
       ]);
 
       const languages = await translationService.getSupportedLanguages('source');
@@ -783,8 +783,8 @@ describe('TranslationService', () => {
 
     it('should return supported target languages', async () => {
       mockDeepLClient.getSupportedLanguages.mockResolvedValue([
-        { language: 'es' as Language, name: 'Spanish' },
-        { language: 'fr' as Language, name: 'French' },
+        { language: 'es', name: 'Spanish' },
+        { language: 'fr', name: 'French' },
       ]);
 
       const languages = await translationService.getSupportedLanguages('target');
@@ -795,7 +795,7 @@ describe('TranslationService', () => {
 
     it('should cache supported languages', async () => {
       mockDeepLClient.getSupportedLanguages.mockResolvedValue([
-        { language: 'en' as Language, name: 'English' },
+        { language: 'en', name: 'English' },
       ]);
 
       await translationService.getSupportedLanguages('source');

--- a/tests/unit/voice-command.test.ts
+++ b/tests/unit/voice-command.test.ts
@@ -454,7 +454,7 @@ describe('VoiceCommand', () => {
     it('should render target transcript when onTargetTranscript is invoked', async () => {
       mockService.translateFile.mockImplementation((_file, _opts, callbacks) => {
         callbacks!.onTargetTranscript!({
-          language: 'de' as any,
+          language: 'de',
           concluded: [{ text: 'Hallo', start_time: 0, end_time: 0.5 }],
           tentative: [],
         });
@@ -516,7 +516,7 @@ describe('VoiceCommand', () => {
     it('should display tentative text in target transcript', async () => {
       mockService.translateFile.mockImplementation((_file, _opts, callbacks) => {
         callbacks!.onTargetTranscript!({
-          language: 'de' as any,
+          language: 'de',
           concluded: [],
           tentative: [{ text: 'Hal', start_time: 0, end_time: 0.3 }],
         });
@@ -534,7 +534,7 @@ describe('VoiceCommand', () => {
     it('should ignore target transcript for unknown language', async () => {
       mockService.translateFile.mockImplementation((_file, _opts, callbacks) => {
         callbacks!.onTargetTranscript!({
-          language: 'es' as any,
+          language: 'es',
           concluded: [{ text: 'Hola', start_time: 0, end_time: 0.5 }],
           tentative: [],
         });
@@ -641,17 +641,17 @@ describe('VoiceCommand', () => {
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'de' as any,
+          language: 'de',
           concluded: [{ text: 'Hallo', start_time: 0, end_time: 0.5 }],
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'fr' as any,
+          language: 'fr',
           concluded: [{ text: 'Bonjour', start_time: 0, end_time: 0.5 }],
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'es' as any,
+          language: 'es',
           concluded: [{ text: 'Hola', start_time: 0, end_time: 0.5 }],
           tentative: [],
         });
@@ -684,12 +684,12 @@ describe('VoiceCommand', () => {
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'de' as any,
+          language: 'de',
           concluded: [{ text: 'Hallo', start_time: 0, end_time: 0.3 }],
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'fr' as any,
+          language: 'fr',
           concluded: [{ text: 'Salut', start_time: 0, end_time: 0.3 }],
           tentative: [],
         });
@@ -720,7 +720,7 @@ describe('VoiceCommand', () => {
             tentative: [],
           });
           callbacks!.onTargetTranscript!({
-            language: 'de' as any,
+            language: 'de',
             concluded: [{ text: 'Hallo', start_time: 0, end_time: 0.5 }],
             tentative: [],
           });
@@ -803,7 +803,7 @@ describe('VoiceCommand', () => {
           tentative: [],
         });
         callbacks!.onTargetTranscript!({
-          language: 'de' as any,
+          language: 'de',
           concluded: [{ text: 'Prüfung', start_time: 0, end_time: 0.3 }],
           tentative: [],
         });

--- a/tests/unit/watch-command.test.ts
+++ b/tests/unit/watch-command.test.ts
@@ -117,7 +117,7 @@ describe('WatchCommand', () => {
       (fs.mkdirSync as jest.Mock).mockReturnValue(undefined);
 
       // Mock process.on to avoid hanging tests
-      jest.spyOn(process, 'on').mockImplementation(() => process as any);
+      jest.spyOn(process, 'on').mockImplementation(() => process);
     });
 
     it('should throw error for non-existent path', async () => {
@@ -395,7 +395,7 @@ describe('WatchCommand', () => {
       (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
 
       // Mock the watch service watch method to return a resolved promise
-      mockWatchService.watch.mockReturnValue(undefined as any);
+      mockWatchService.watch.mockReturnValue(undefined);
 
       // Start watch - it will reach the infinite Promise and hang there
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -596,7 +596,7 @@ describe('WatchCommand', () => {
       (fs.existsSync as jest.Mock).mockReturnValue(true);
       (fs.statSync as jest.Mock).mockReturnValue({ isDirectory: () => false });
       (fs.mkdirSync as jest.Mock).mockReturnValue(undefined);
-      jest.spyOn(process, 'on').mockImplementation(() => process as any);
+      jest.spyOn(process, 'on').mockImplementation(() => process);
     });
 
     it('should call getStagedFiles and pass result to WatchService when gitStaged is true', async () => {

--- a/tests/unit/write-command.test.ts
+++ b/tests/unit/write-command.test.ts
@@ -127,7 +127,7 @@ describe('WriteCommand', () => {
         };
         mockWriteService.getBestImprovement.mockResolvedValue(mockImprovement);
 
-        const result = await writeCommand.improve('Test', {} as any);
+        const result = await writeCommand.improve('Test', {});
 
         expect(result).toBe('Improved text.');
       });


### PR DESCRIPTION
## Summary

typescript-eslint 8.59 (dependabot PR #38) tightened the \`no-unnecessary-type-assertion\` rule, surfacing 197 stale type assertions across src/ and tests/. This PR applies the auto-fixes ahead of #38 so its CI can go green on rebase.

## Changes Made

- **Auto-applied** \`npm run lint:fix\` — removed unnecessary \`as\` assertions across 44 files (197 total)
- **Manually fixed** 3 test-file unused-import errors (TS6133) that surfaced after assertions were removed:
  - \`tests/unit/glossary-command.test.ts\`: drop unused \`Language\` import
  - \`tests/unit/cli-translate-workflow.test.ts\`: drop unused \`Language\` import
  - \`tests/unit/sync/sync-command.test.ts\`: drop unused \`CliSyncOptions\` import

## Verification

Locally on commit cc88078:

- ✅ \`npm run lint\` — clean
- ✅ \`npm run type-check\` — clean
- ✅ \`npm test\` — 5490/5490 pass
- ✅ \`npm run build\` — clean
- ✅ Example workflows (15, 30, 32, 35, 13) — all exit 0

## Backward Compatibility

✅ **Maintained**: No runtime behavior change. Pure type-system / lint cleanup. Type assertions removed were verifiably unnecessary (assert against the same inferred type).

## Size: Small ✓

Mechanical refactor; large file count, tiny per-file diff (1–2 lines each).

🤖 Generated with [Claude Code](https://claude.ai/code)