### PR TITLE
chore(deps): group minor and patch dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,19 @@ updates:
       interval: weekly
     target-branch: main
     open-pull-requests-limit: 10
+    groups:
+      npm-minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     target-branch: main
+    groups:
+      github-actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Group npm and github-actions minor/patch dependency updates into a single PR per ecosystem to reduce PR noise. Major updates continue to get individual PRs.