### PR TITLE
docs: stop instructing readers to npm install the unpublished package

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,21 @@ deepl --version
 > - **Linux**: `python3`, `make`, and `gcc` (`apt install python3 make gcc g++`)
 > - **Windows**: Visual Studio Build Tools or `windows-build-tools` (`npm install -g windows-build-tools`)
 
-### From npm (not yet published)
+### From npm
 
-An npm package is not yet published; install from source until then.
+The npm package has not been published yet. Until it is, install from source
+using the **From Source** instructions above. The CI examples in this README,
+in [`docs/SYNC.md`](docs/SYNC.md), and in [`examples/`](examples/) install from
+the GitHub repository directly (`git clone … && npm ci && npm run build &&
+npm link`) so they work today without a published package; they can be
+shortened to `npm install -g deepl-cli` once the package is on the public
+registry.
 
-> **CI examples below** (and generated hook output) assume a published npm package; source-installed users should substitute the source-install path.
+> **Security note.** Do not run `npm install -g deepl-cli` against the public
+> registry today — there is no official package under that name yet, so any
+> match would be a third-party publish. Use the source install (or pin a
+> specific commit / signed release tag of this repository in CI) until an
+> official scoped package is announced.
 
 ## 🚀 Quick Start
 

--- a/docs/SYNC.md
+++ b/docs/SYNC.md
@@ -808,7 +808,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install -g deepl-cli
+      # The npm package is not yet published; install from source.
+      # Pin to a specific tag/commit for reproducible builds.
+      - name: Install DeepL CLI
+        run: |
+          git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+          cd /tmp/deepl-cli && npm ci && npm run build && npm link
       - name: Check translations are up to date
         run: deepl sync --frozen
         env:
@@ -832,7 +837,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm install -g deepl-cli
+      - name: Install DeepL CLI
+        run: |
+          git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+          cd /tmp/deepl-cli && npm ci && npm run build && npm link
       - name: Sync and commit translations
         run: |
           git config user.name "github-actions[bot]"
@@ -862,8 +870,11 @@ The `.deepl-sync.lock` file is only staged when this sync run actually wrote an 
 i18n-check:
   stage: test
   image: node:20
+  before_script:
+    # The npm package is not yet published; install from source.
+    - git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+    - cd /tmp/deepl-cli && npm ci && npm run build && npm link && cd -
   script:
-    - npm install -g deepl-cli
     - deepl sync --frozen
   variables:
     DEEPL_API_KEY: $DEEPL_API_KEY

--- a/examples/05-document-translation.sh
+++ b/examples/05-document-translation.sh
@@ -83,7 +83,7 @@ Key Features:
 - Real-time file watching
 
 Installation:
-npm install -g deepl-cli
+See the project README for installation instructions.
 
 Usage:
 deepl translate "Hello, world!" --to es

--- a/examples/12-cost-transparency.sh
+++ b/examples/12-cost-transparency.sh
@@ -86,11 +86,7 @@ echo "   Creating a technical document with code..."
 cat > "$TEMP_DIR/technical.md" << 'EOF'
 # Installation Guide
 
-Run the following command:
-
-```bash
-npm install deepl-cli
-```
+Install DeepL CLI from source (see the project README).
 
 Then configure your API key: `deepl auth set-key YOUR_KEY`
 EOF

--- a/examples/18-cicd-integration.sh
+++ b/examples/18-cicd-integration.sh
@@ -138,8 +138,12 @@ jobs:
         with:
           node-version: '20'
 
+      # The npm package is not yet published; install from source.
+      # Pin to a tag/commit for reproducible builds in production.
       - name: Install DeepL CLI
-        run: npm install -g deepl-cli
+        run: |
+          git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+          cd /tmp/deepl-cli && npm ci && npm run build && npm link
 
       - name: Configure API Key
         env:

--- a/examples/31-sync-ci.sh
+++ b/examples/31-sync-ci.sh
@@ -117,7 +117,11 @@ cat << 'WORKFLOW'
        runs-on: ubuntu-latest
        steps:
          - uses: actions/checkout@v4
-         - run: npm install -g deepl-cli
+         # The npm package is not yet published; install from source.
+         - name: Install DeepL CLI
+           run: |
+             git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+             cd /tmp/deepl-cli && npm ci && npm run build && npm link
          - name: Check translations are up to date
            run: deepl sync --frozen
            env:
@@ -132,8 +136,11 @@ cat << 'GITLAB'
    i18n-check:
      stage: test
      image: node:20
+     before_script:
+       # The npm package is not yet published; install from source.
+       - git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+       - (cd /tmp/deepl-cli && npm ci && npm run build && npm link)
      script:
-       - npm install -g deepl-cli
        - deepl sync --frozen
      variables:
        DEEPL_API_KEY: $DEEPL_API_KEY
@@ -158,7 +165,11 @@ cat << 'AUTOSYNC'
        runs-on: ubuntu-latest
        steps:
          - uses: actions/checkout@v4
-         - run: npm install -g deepl-cli
+         # The npm package is not yet published; install from source.
+         - name: Install DeepL CLI
+           run: |
+             git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli
+             cd /tmp/deepl-cli && npm ci && npm run build && npm link
          - name: Sync translations
            run: deepl sync --format json
            env:

--- a/examples/README.md
+++ b/examples/README.md
@@ -73,7 +73,7 @@ This directory contains practical, real-world examples of using the DeepL CLI.
 
 All examples assume you have:
 
-1. Installed DeepL CLI (`npm install -g deepl-cli` or `npm link`)
+1. Installed DeepL CLI from source (see [`README.md` → From Source](../README.md#from-source); the npm package is not yet published)
 2. A DeepL API key configured (`deepl auth set-key YOUR_API_KEY`)
 
 ## Running Examples


### PR DESCRIPTION
## Summary

The README, `docs/SYNC.md`, and several `examples/*.sh` CI snippets currently tell readers to run `npm install -g deepl-cli`, but no package exists under that name on the public npm registry. That has two practical problems:

- **Following the instructions doesn't work today.** Anyone copy-pasting the CI snippets gets `404 Not Found` from the registry.
- **It primes the project for a supply-chain footgun.** As long as the docs name `deepl-cli` as the install target, a third party who registers something under or adjacent to that name on the public registry can serve code to anyone who follows the docs. (The README's `> CI examples below ... assume a published npm package; source-installed users should substitute the source-install path` caveat is easy to miss in the middle of a quickstart.)

This PR is docs-only. It replaces the speculative `npm install -g deepl-cli` invocations with the source-install path that already works (`git clone … && npm ci && npm run build && npm link`) so the examples run today, and rewrites the README's *From npm* section to be explicit about the current state plus a short security note about not running the speculative `npm install` against the public registry until an official (ideally scoped, e.g. `@deepl/cli`) package is published.

### Files changed

- `README.md` — rewrite the *From npm (not yet published)* section; add a security note.
- `docs/SYNC.md` — replace `npm install -g deepl-cli` in all three CI YAML snippets (GitHub Actions check, GitHub Actions auto-sync, GitLab CI) with the source install.
- `examples/18-cicd-integration.sh`, `examples/31-sync-ci.sh` — same replacement in the heredoc YAML they print.
- `examples/README.md` — point readers at the *From Source* section instead of the speculative npm command.
- `examples/05-document-translation.sh`, `examples/12-cost-transparency.sh` — these were translating fixture text that happened to read `npm install -g deepl-cli`; swapped to neutral wording so the repo contains no copy-pasteable speculative install line.

### Follow-ups out of scope here

- Publishing an official scoped package (e.g. `@deepl/cli`) and switching the docs back to `npm install -g @deepl/cli`.
- Adding a `prepare` script to `package.json` so `npm install -g github:DeepLcom/deepl-cli` would Just Work and the CI snippets could collapse to a single line. Left out of this PR to keep it docs-only.

## Test plan

- [ ] `grep -rn "npm install.*deepl-cli" --include='*.md' --include='*.sh' --include='*.yml' --include='*.yaml'` returns only the two intentional mentions in `README.md` (the future-state sentence and the security warning).
- [ ] The new install snippet runs end-to-end on a clean Ubuntu image: `git clone --depth 1 https://github.com/DeepLcom/deepl-cli.git /tmp/deepl-cli && cd /tmp/deepl-cli && npm ci && npm run build && npm link && deepl --version`.
- [ ] Render the README and `docs/SYNC.md` on GitHub and confirm the rewritten sections are readable and the CI YAML still parses.