### PR TITLE
ci: target Node 24 in test, release, and security workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [24]
 
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: https://registry.npmjs.org
           cache: npm
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           cache: npm
 
       - run: npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ci**: Test matrix, release workflow, and security workflow now target Node 24 (previously Node 20 and 22). Node 20 reached end-of-life in April 2026, and Node 24 is the current LTS. This aligns CI with the runtime the project is moving to; the `engines.node` range is unchanged in this entry and is bumped separately.
+
 ### Fixed
 
 - **sync**: `deepl sync --frozen` now reports an accurate key count when drift is caused by a newly-added target locale. Previously the message read `Sync drift detected: 0 new, 0 stale keys.` because the frozen branch in `processBucket` short-circuited before promoting current-status keys missing a target-locale translation into `newKeys` — even though `--dry-run` against the same state correctly reported the backfill count. The drift exit code (10) is unchanged. The drift message now also surfaces `deletedKeys` and only mentions nonzero categories, mirroring the success-path summary format.


### PR DESCRIPTION
## Summary

Points CI, release, and security workflows at **Node 24**, replacing the Node 20 / 22 matrix. Node 20 reached end-of-life in April 2026; Node 24 is the current LTS. This is the first step of the v2.0.0 release work, which moves the cache backend from `better-sqlite3` to the built-in `node:sqlite` — a module that is only stable from Node 24.

### Changes Made

- **`ci.yml`** — test matrix `[20, 22]` → `[24]`
- **`release.yml`** — `node-version: '20'` → `'24'`
- **`security.yml`** — `node-version: '20'` → `'24'`
- **`CHANGELOG.md`** — `### Changed` entry under `Unreleased`

### Why `[24]` and not `[24, 25]`

The matrix should track the supported `engines` range, not a runtime the project does not claim to support. Testing 25 would surface failures from a version we would not act on. Worth revisiting when Node 26 lands.

### Why `security.yml` is included

It runs `npm ci`, which will emit `EBADENGINE` once `engines.node` requires 24. Leaving it on Node 20 would produce noise on every run.

### Test Coverage

No test changes — this is CI configuration. Verified locally against **Node 24.18.0**:

```
npm run type-check    pass
npm run lint          pass
npm run build         pass
npm test              231 suites / 5493 tests passed  (40.9s, vs 54.2s on Node 22)
```

Also confirmed `node:sqlite` is non-experimental on 24 (no `ExperimentalWarning` on load) and bundles SQLite 3.53.1, effectively matching the 3.53.2 that `better-sqlite3` ships today.

### Backward Compatibility

✅ **No runtime change** — `engines.node` is untouched by this PR and still reads `>=20.19.0`. The bump to `>=24` lands with the `node:sqlite` migration.
⚠️ **CI coverage narrows** — Node 20 and 22 are no longer exercised. Deliberate: the release they are gating on will require 24.
❌ **Breaking changes**: none in this PR.

### Size: Small ✓

Three one-line workflow edits plus a changelog entry.
