### PR TITLE
build(deps): bump commander from 14.0.3 to 15.0.0 (with jest ESM transform fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **deps**: `commander` 14.0.3 → 15.0.0. commander 15 is ESM-only (`"type": "module"`) and requires Node >=22.12.0, so it was unmergeable until the Node 24 baseline landed. Jest's `transformIgnorePatterns` allowlist gains `commander` so ts-jest transforms it under CommonJS test execution; without that, 28 suites fail to load with `SyntaxError: Cannot use import statement outside a module`.
 - **ci**: Test matrix, release workflow, and security workflow now target Node 24 (previously Node 20 and 22). Node 20 reached end-of-life in April 2026, and Node 24 is the current LTS. This aligns CI with the runtime the project is moving to; the `engines.node` range is unchanged in this entry and is bumped separately.
 
 ### Fixed

--- a/jest.config.js
+++ b/jest.config.js
@@ -75,7 +75,7 @@ export default {
 
   // Transform ESM packages
   transformIgnorePatterns: [
-    'node_modules/(?!(p-limit|yocto-queue|fast-glob|chalk|chokidar|readdirp)/)',
+    'node_modules/(?!(p-limit|yocto-queue|fast-glob|chalk|chokidar|readdirp|commander)/)',
   ],
 
   // Setup files

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "chalk": "^5.3.0",
         "chokidar": "^5.0.0",
         "cli-table3": "^0.6.5",
-        "commander": "^14.0.0",
+        "commander": "^15.0.0",
         "fast-glob": "^3.3.3",
         "form-data": "^4.0.4",
         "inquirer": "^13.4.2",
@@ -4428,12 +4428,12 @@
       }
     },
     "node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/concat-map": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chalk": "^5.3.0",
     "chokidar": "^5.0.0",
     "cli-table3": "^0.6.5",
-    "commander": "^14.0.0",
+    "commander": "^15.0.0",
     "fast-glob": "^3.3.3",
     "form-data": "^4.0.4",
     "inquirer": "^13.4.2",


### PR DESCRIPTION
## Summary

Completes the `commander` 14.0.3 → 15.0.0 bump that #83 could not land on its own. **Supersedes #83** — the dependency bump is dependabot's; this adds the one change needed to make it pass.

### Why #83 failed

commander 15 changed two things that mattered:

| | commander 14 | commander 15 |
|---|---|---|
| Module format | `commonjs` | **`module`** (ESM-only) |
| `engines.node` | — | **`>=22.12.0`** |

Under ts-jest's CommonJS test execution, importing an ESM-only package produced:

```
node_modules/commander/index.js:1
import { Argument } from './lib/argument.js';
^^^^^^
SyntaxError: Cannot use import statement outside a module
```

That failed **28 suites at load time** — note the original run reported `5105 passed, 0 failed`, because nothing got as far as asserting.

The `engines` requirement also made it genuinely unmergeable until the Node 24 baseline landed in #90.

### Changes Made

- **`package.json` / `package-lock.json`** — `commander` `^14.0.3` → `^15.0.0`
- **`jest.config.js`** — added `commander` to the existing `transformIgnorePatterns` ESM allowlist, alongside `p-limit`, `yocto-queue`, `fast-glob`, `chalk`, `chokidar`, `readdirp`:

  ```diff
  - 'node_modules/(?!(p-limit|yocto-queue|fast-glob|chalk|chokidar|readdirp)/)',
  + 'node_modules/(?!(p-limit|yocto-queue|fast-glob|chalk|chokidar|readdirp|commander)/)',
  ```
- **`CHANGELOG.md`** — `### Changed` entry under `Unreleased`

No source changes. commander 15's API is compatible with our usage; only the test harness needed adjusting. This follows the project's stated policy of refactoring for ESM rather than pinning back to avoid it.

### Test Coverage

No new tests. Verified on **Node 24.18.0**:

```
npm run type-check    pass
npm test              231 suites / 5493 tests passed, 0 failed
```

### Backward Compatibility

✅ **No CLI behaviour change** — argument parsing, help output, and exit codes are unaffected; the full integration and e2e suites pass unmodified.
⚠️ **Raises the effective floor to Node ≥22.12.0** via commander's own `engines`. Already satisfied by the Node 24 CI baseline, and `engines.node` in this package is bumped to `>=24` separately as part of the v2.0.0 work.
❌ **Breaking changes**: none.

### Size: Small ✓

Three files; one dependency bump and one regex addition.

Closes #83.
