### PR TITLE
ci(release): enable npm publish, create GitHub Releases on tag, add gated Homebrew bump job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Release
 
 on:
   push:
@@ -6,10 +6,9 @@ on:
       - 'v*'
 
 jobs:
+  # The publish and release jobs are deliberately independent: a failure
+  # in one must not suppress the other.
   publish:
-    # Disabled until npm publish permission is granted.
-    # To enable: remove the `if: false` line and add an NPM_TOKEN secret.
-    if: false
     runs-on: ubuntu-latest
 
     permissions:
@@ -27,6 +26,79 @@ jobs:
 
       - run: npm ci
       - run: npm run build
+      # First publish authenticates with a granular NPM_TOKEN scoped to
+      # @deepl/cli. Switch to OIDC trusted publishing once the package
+      # exists on npmjs.com, then revoke the token (tracked in beads).
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  release:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # Release notes come from the tag's CHANGELOG section; releases are
+      # immutable once published, but notes stay editable afterwards.
+      - name: Extract changelog section
+        id: notes
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          awk -v ver="$version" '
+            $0 ~ "^## \\[" ver "\\]" { found = 1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            echo "has_notes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ steps.notes.outputs.has_notes }}" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" --notes-file release-notes.md
+          else
+            gh release create "$GITHUB_REF_NAME" --verify-tag \
+              --title "$GITHUB_REF_NAME" --generate-notes
+          fi
+
+  # Gated until DeepL/homebrew-tap exists and a HOMEBREW_TAP_TOKEN secret
+  # (a fine-grained PAT with contents + pull-requests write on that repo)
+  # is configured — see the Homebrew tap issue. github.token cannot push
+  # cross-repo. To enable: change `if:` to `if: ${{ !cancelled() }}`.
+  homebrew:
+    if: false
+    needs: publish
+    runs-on: ubuntu-latest
+
+    permissions: {}
+
+    steps:
+      - name: Bump formula version and sha256
+        env:
+          GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          version="${GITHUB_REF_NAME#v}"
+          url="https://registry.npmjs.org/@deepl/cli/-/cli-${version}.tgz"
+          curl -fsSL -o cli.tgz "$url"
+          sha256="$(sha256sum cli.tgz | cut -d' ' -f1)"
+
+          gh repo clone DeepL/homebrew-tap tap
+          cd tap
+          branch="bump-deepl-${version}"
+          git checkout -b "$branch"
+          sed -i -E "s|^(  url \").*(\")$|\1${url}\2|" Formula/deepl.rb
+          sed -i -E "s|^(  sha256 \").*(\")$|\1${sha256}\2|" Formula/deepl.rb
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git commit -am "deepl ${version}"
+          git push -u origin "$branch"
+          gh pr create --title "deepl ${version}" \
+            --body "Automated formula bump for @deepl/cli ${version}. sha256: \`${sha256}\`"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ci**: Pushing a `v*` tag now runs the full release pipeline. The npm publish job is enabled (it was hard-disabled with `if: false` since its introduction, which is why the repo has 17 tags and zero GitHub Releases); it authenticates with a granular `NPM_TOKEN` for the first publish and keeps `--provenance` attestation. A new, deliberately independent `release` job creates a GitHub Release from the tag, with notes extracted from the version's CHANGELOG section (falling back to generated notes if the section is missing) — a publish failure cannot suppress the Release, and vice versa. A `homebrew` formula-bump job (version + sha256 PR against `DeepL/homebrew-tap`) ships gated with `if: false` until the tap repo and its cross-repo token exist.
+
 ### Changed
 
 - **BREAKING — package**: The package is now published as the scoped **`@deepl/cli`** (previously the unpublished working name `deepl-cli`). Scoped packages default to restricted visibility, so `publishConfig.access: "public"` is set explicitly — without it the publish fails. The `bin` name is unchanged: the command is still `deepl`, and scoping changes only the install string (`npm install -g @deepl/cli`). Repository, bugs, and homepage metadata now point at `github.com/DeepL/deepl-cli` directly instead of relying on the redirect from the legacy `DeepLcom` org name.


### PR DESCRIPTION
## Summary

Turns the tag-triggered release pipeline on (sync-8mqh.5). The npm publish job has been hard-disabled (`if: false`) since its introduction — which is also why the repo has 17 annotated tags and zero GitHub Releases. After this PR, pushing a `v*` tag publishes to npm with provenance AND creates a GitHub Release, as two independent jobs.

### Changes Made

- **`publish` job** — removed `if: false`. Authenticates via a granular `NPM_TOKEN` secret scoped to `@deepl/cli` (required for the FIRST publish; npm's OIDC trusted-publishing config lives in package settings, so the package must exist before OIDC can be configured — switch and revoke the token afterwards). `--provenance` retained; the job already grants `id-token: write`.
- **`release` job** (new) — creates a GitHub Release from the pushed tag (`gh release create --verify-tag`), with notes extracted from that version's CHANGELOG section via awk; if the section is missing it falls back to `--generate-notes`. Runs with `contents: write`, independent of `publish` by design: a publish failure cannot suppress the Release and vice versa. Compatible with release immutability (assets/tag freeze at publish; notes stay editable).
- **`homebrew` job** (new, gated `if: false`) — downloads the published registry tarball, computes its sha256, and opens a version-bump PR against `DeepL/homebrew-tap`. Gated until the tap repo and a cross-repo `HOMEBREW_TAP_TOKEN` fine-grained PAT exist (the default `github.token` cannot push cross-repo); the gate and enable instructions are documented in the workflow comment.
- Workflow renamed `Publish to npm` → `Release` to reflect its wider role.
- Uses only `actions/checkout`/`actions/setup-node` (already allowlisted) plus the runner's `gh` CLI — no new third-party actions, which matters since repo Actions permissions are set to "selected".

### Test Coverage

Workflow logic is not unit-testable from jest, so the fragile pieces were verified directly:
- YAML parses cleanly.
- The awk changelog extraction was run against the real CHANGELOG.md: a present version (`1.2.0`) yields exactly its section; an absent version yields empty output, triggering the `--generate-notes` fallback.
- End-to-end verification happens at the v2.0.0 tag push (sync-w79t), which is the next issue in the sequence and the first real firing of this pipeline.

### Backward Compatibility

✅ No runtime/user-facing behavior changes — CI-only.
⚠️ Operational prerequisite: the `NPM_TOKEN` repo secret must exist before the v2.0.0 tag is pushed, or the publish job fails (the Release job still runs, by design).

### Size: Small ✓

One workflow file; the risk is operational (first firing at tag time), mitigated by job independence and the gated Homebrew job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)