### PR TITLE
test(e2e): isolate sync option-routing children from ambient NODE_OPTIONS

### DIFF
--- a/tests/e2e/cli-sync-option-routing.e2e.test.ts
+++ b/tests/e2e/cli-sync-option-routing.e2e.test.ts
@@ -78,6 +78,10 @@ describe('CLI sync option routing E2E', () => {
         DEEPL_API_KEY: 'mock-api-key-for-testing:fx',
         NO_COLOR: '1',
         CI: undefined,
+        // Ambient NODE_OPTIONS can make node print warnings to stderr, which
+        // the JSON-envelope assertions parse.
+        NODE_OPTIONS: undefined,
+        NODE_NO_WARNINGS: '1',
       },
       stdio: ['ignore', 'pipe', 'pipe'],
       timeout: 15000,


### PR DESCRIPTION
## Summary

Fixes the environment-dependent failure in `cli-sync-option-routing.e2e.test.ts`: the `runCli` helper spread `process.env` into the spawned CLI process, so a shell whose `NODE_OPTIONS` causes node to print a startup warning (`(node:<pid>) …`) polluted stderr ahead of the JSON error envelope, breaking `JSON.parse` in the `--format json` assertion.

### Changes Made

- `runCli` child env now drops `NODE_OPTIONS` and sets `NODE_NO_WARNINGS=1`, matching `cli-cache-degraded.e2e.test.ts`'s existing handling.

### Test Coverage

Reproduced deterministically with `NODE_OPTIONS='--require <script calling process.emitWarning>'`: **1 failed / 19 passed** before the fix, **20/20** after, and 20/20 in a clean environment. This is the only e2e suite that parses stderr as JSON.

### Backward Compatibility

✅ Test-only change; no production code touched.

### Size: Small ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)